### PR TITLE
update symlink to new snips-config folder

### DIFF
--- a/snips/run.sh
+++ b/snips/run.sh
@@ -48,7 +48,7 @@ mosquitto -c /etc/mosquitto.conf &
 
 # init snips config
 mkdir -p "$SNIPS_CONFIG"
-ln -s "$SNIPS_CONFIG/" "/opt/snips/config"
+ln -s "$SNIPS_CONFIG/" "/usr/share/snips"
 
 # check if a new assistant file exists
 if [ -f "/share/$ASSISTANT" ]; then


### PR DESCRIPTION
snips-0.6.5 uses a new config folder which is now `/usr/share/snips`